### PR TITLE
Use console.dir with options for complete output

### DIFF
--- a/dump_shc.js
+++ b/dump_shc.js
@@ -33,7 +33,7 @@ console.log("-----");
 
 verifyJWS(scannedJWS).then(
   function (result) {
-    return decodeJWS(scannedJWS).then((decoded) => console.log(decoded));
+    return decodeJWS(scannedJWS).then((decoded) => console.dir(decoded, {depth:null, compact:false}));
   },
   function (e) {
     console.log("Ooooh crap - this looks like a fake vacinnation proof");


### PR DESCRIPTION
This (using Node 10) wasn't logging the entire BC vax card object because it was too deeply nested for the default `console.log()` behaviour.  Replacing `.log(obj)` with `.dir(obj, options)` prints the entire object.

Fixes #2.